### PR TITLE
Riadgahlouz/modernize

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ After starting `andydb.exe`, you can make simple RESTful CRUD requests to the se
 
 For example, `curl -d '{"email": "andy@andy.db"}' http://localhost:42069/api/contacts` will create the contacts resource
 type (since it does not exist yet) and will save the provided body as an entry of that resource. 
-It will return with the created object in JSON format, and with a new field `_id`, to be used for future operations.
-Subsequent POST requests to the contacts resource will append the entry to the list of contacts.
+It will return the created object in JSON format with a new field `_id` (now a UUID v7) that can be used for future operations.
+Subsequent POST requests to the contacts resource append each entry to that collection.
 
 With the `_id` you may now perform a GET / PUT / DELETE requests in the format of:
 
@@ -22,10 +22,17 @@ With the `_id` you may now perform a GET / PUT / DELETE requests in the format o
   - `curl http://localhost:42069/api/contacts/{_id}`
 - PUT `http://localhost:42069/api/contacts/{_id}` 
   - `curl -X PUT -d '{"email": "db@andy.db"}' http://localhost:42069/api/contacts/{_id}`
-- DELETE `http://localhost:42069/api/contacts/{_id}` (
+- DELETE `http://localhost:42069/api/contacts/{_id}`
 - `curl -X DELETE http://localhost:42069/api/contacts/{_id}`
 
 If you don't provide the id for a GET request, it will return all entries of the resource.
+
+## Development hints
+
+- Run `ANDYDB_ENV=dev go run .` (or omit the env var when using `go run .`, it defaults to dev) so the server logs every request and emits the startup banner with the current mode.
+- The server already enforces a 1 MB JSON body limit, trims malformed bodies, and wraps every handler with recovery middleware, so panicked handlers just return 500s.
+- The in-memory datastore now uses mutex guards plus UUID v7 keys and has race-tested coverage in `app/database/concurrency_test.go`.
+- Graceful shutdown is wired through `signal.NotifyContext`, so `Ctrl+C` closes the HTTP listener cleanly.
 
 ## Upcoming Features
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ With the `_id` you may now perform a GET / PUT / DELETE requests in the format o
 - PUT `http://localhost:42069/api/contacts/{_id}` 
   - `curl -X PUT -d '{"email": "db@andy.db"}' http://localhost:42069/api/contacts/{_id}`
 - DELETE `http://localhost:42069/api/contacts/{_id}` (
-  - `curl -X PUT http://localhost:42069/api/contacts/{_id}`
+- `curl -X DELETE http://localhost:42069/api/contacts/{_id}`
 
 If you don't provide the id for a GET request, it will return all entries of the resource.
 

--- a/app/app.go
+++ b/app/app.go
@@ -1,8 +1,10 @@
 package app
 
 import (
-	"log"
+	"context"
+	"errors"
 	"net/http"
+	"time"
 
 	"github.com/andy-ta/andydb/app/database"
 	"github.com/andy-ta/andydb/app/handler"
@@ -12,6 +14,14 @@ import (
 type App struct {
 	Router   *mux.Router
 	Database database.Resources
+}
+
+type ServerConfig struct {
+	Addr            string
+	ReadTimeout     time.Duration
+	WriteTimeout    time.Duration
+	IdleTimeout     time.Duration
+	ShutdownTimeout time.Duration
 }
 
 func (a *App) Initialize() {
@@ -29,8 +39,57 @@ func (a *App) setRouters() {
 	r.HandleFunc("/{resource}/{id}", a.handleRequest(handler.Delete)).Methods("DELETE")
 }
 
-func (a *App) Run(host string) {
-	log.Fatal(http.ListenAndServe(host, a.Router))
+func (a *App) Run(ctx context.Context, cfg ServerConfig) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg.normalize()
+	srv := &http.Server{
+		Addr:         cfg.Addr,
+		Handler:      a.Router,
+		ReadTimeout:  cfg.ReadTimeout,
+		WriteTimeout: cfg.WriteTimeout,
+		IdleTimeout:  cfg.IdleTimeout,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.ListenAndServe()
+	}()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		if err := <-errCh; err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return ctx.Err()
+	case err := <-errCh:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return nil
+	}
+}
+
+func (cfg *ServerConfig) normalize() {
+	if cfg.Addr == "" {
+		cfg.Addr = ":42069"
+	}
+	if cfg.ReadTimeout == 0 {
+		cfg.ReadTimeout = 5 * time.Second
+	}
+	if cfg.WriteTimeout == 0 {
+		cfg.WriteTimeout = 5 * time.Second
+	}
+	if cfg.IdleTimeout == 0 {
+		cfg.IdleTimeout = 120 * time.Second
+	}
+	if cfg.ShutdownTimeout == 0 {
+		cfg.ShutdownTimeout = 5 * time.Second
+	}
 }
 
 type RequestHandlerFunction func(w http.ResponseWriter, r *http.Request, database database.Resources)

--- a/app/app.go
+++ b/app/app.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"runtime/debug"
 	"time"
 
 	"github.com/andy-ta/andydb/app/database"
@@ -52,6 +53,7 @@ func (a *App) Run(ctx context.Context, cfg ServerConfig) error {
 	}
 	log.Printf("AndyDB running on %s (%s mode)", cfg.Addr, mode)
 	handler := http.Handler(a.Router)
+	handler = a.recoverer(handler)
 	if cfg.DevMode {
 		handler = a.requestLogger(handler)
 	}
@@ -114,6 +116,18 @@ func (a *App) handleRequest(handler RequestHandlerFunction) http.HandlerFunc {
 func (a *App) requestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[DEV] %s %s from %s", r.Method, r.RequestURI, r.RemoteAddr)
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (a *App) recoverer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil {
+				log.Printf("panic recovered: %v\n%s", rec, debug.Stack())
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+			}
+		}()
 		next.ServeHTTP(w, r)
 	})
 }

--- a/app/app.go
+++ b/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 	"time"
 
@@ -22,6 +23,7 @@ type ServerConfig struct {
 	WriteTimeout    time.Duration
 	IdleTimeout     time.Duration
 	ShutdownTimeout time.Duration
+	DevMode         bool
 }
 
 func (a *App) Initialize() {
@@ -44,9 +46,18 @@ func (a *App) Run(ctx context.Context, cfg ServerConfig) error {
 		ctx = context.Background()
 	}
 	cfg.normalize()
+	mode := "production"
+	if cfg.DevMode {
+		mode = "development"
+	}
+	log.Printf("AndyDB running on %s (%s mode)", cfg.Addr, mode)
+	handler := http.Handler(a.Router)
+	if cfg.DevMode {
+		handler = a.requestLogger(handler)
+	}
 	srv := &http.Server{
 		Addr:         cfg.Addr,
-		Handler:      a.Router,
+		Handler:      handler,
 		ReadTimeout:  cfg.ReadTimeout,
 		WriteTimeout: cfg.WriteTimeout,
 		IdleTimeout:  cfg.IdleTimeout,
@@ -98,4 +109,11 @@ func (a *App) handleRequest(handler RequestHandlerFunction) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		handler(w, r, a.Database)
 	}
+}
+
+func (a *App) requestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("[DEV] %s %s from %s", r.Method, r.RequestURI, r.RemoteAddr)
+		next.ServeHTTP(w, r)
+	})
 }

--- a/app/app.go
+++ b/app/app.go
@@ -46,7 +46,6 @@ func (a *App) Run(ctx context.Context, cfg ServerConfig) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	cfg.normalize()
 	mode := "production"
 	if cfg.DevMode {
 		mode = "development"
@@ -84,24 +83,6 @@ func (a *App) Run(ctx context.Context, cfg ServerConfig) error {
 			return err
 		}
 		return nil
-	}
-}
-
-func (cfg *ServerConfig) normalize() {
-	if cfg.Addr == "" {
-		cfg.Addr = ":42069"
-	}
-	if cfg.ReadTimeout == 0 {
-		cfg.ReadTimeout = 5 * time.Second
-	}
-	if cfg.WriteTimeout == 0 {
-		cfg.WriteTimeout = 5 * time.Second
-	}
-	if cfg.IdleTimeout == 0 {
-		cfg.IdleTimeout = 120 * time.Second
-	}
-	if cfg.ShutdownTimeout == 0 {
-		cfg.ShutdownTimeout = 5 * time.Second
 	}
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -15,7 +15,7 @@ import (
 
 type App struct {
 	Router   *mux.Router
-	Database database.Resources
+	Database *database.Resources
 }
 
 type ServerConfig struct {
@@ -105,7 +105,7 @@ func (cfg *ServerConfig) normalize() {
 	}
 }
 
-type RequestHandlerFunction func(w http.ResponseWriter, r *http.Request, database database.Resources)
+type RequestHandlerFunction func(w http.ResponseWriter, r *http.Request, database *database.Resources)
 
 func (a *App) handleRequest(handler RequestHandlerFunction) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/app/database/concurrency_test.go
+++ b/app/database/concurrency_test.go
@@ -1,0 +1,92 @@
+package database
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestEntriesConcurrentCreate(t *testing.T) {
+	entry := NewEntry()
+	const workers = 10
+	const perWorker = 50
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(worker int) {
+			defer wg.Done()
+			for j := 0; j < perWorker; j++ {
+				entry.Create(map[string]interface{}{"worker": worker, "sequence": j})
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	got := len(entry.ReadAll())
+	want := workers * perWorker
+	if got != want {
+		t.Fatalf("expected %d entries, got %d", want, got)
+	}
+}
+
+func TestResourcesConcurrentNewResource(t *testing.T) {
+	db := NewDatabase()
+	names := []string{"alpha", "beta", "gamma"}
+
+	var wg sync.WaitGroup
+	const goroutines = 15
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(iter int) {
+			defer wg.Done()
+			name := names[iter%len(names)]
+			if err := db.NewResource(name); err != nil && !strings.Contains(err.Error(), "already exists") {
+				t.Errorf("unexpected error: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for _, name := range names {
+		if !db.Exists(name) {
+			t.Fatalf("resource %q should exist", name)
+		}
+		if db.Get(name) == nil {
+			t.Fatalf("resource %q should be retrievable", name)
+		}
+	}
+}
+
+func TestResourcesConcurrentWrites(t *testing.T) {
+	db := NewDatabase()
+	const name = "records"
+	if err := db.NewResource(name); err != nil {
+		t.Fatalf("failed to create resource: %v", err)
+	}
+	resource := db.Get(name)
+	if resource == nil {
+		t.Fatalf("resource %q unexpectedly nil", name)
+	}
+
+	const workers = 6
+	const perWorker = 40
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(worker int) {
+			defer wg.Done()
+			for j := 0; j < perWorker; j++ {
+				resource.Create(map[string]interface{}{"worker": worker, "sequence": j})
+				resource.ReadAll()
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	total := len(resource.ReadAll())
+	want := workers * perWorker
+	if total != want {
+		t.Fatalf("expected %d records, got %d", want, total)
+	}
+}

--- a/app/database/concurrency_test.go
+++ b/app/database/concurrency_test.go
@@ -57,15 +57,15 @@ func TestEntriesConcurrentCreate(t *testing.T) {
 		}
 		ids[id] = struct{}{}
 
-		worker, ok := record["worker"].(float64)
+		worker, ok := numberAsInt(record["worker"])
 		if !ok {
 			t.Fatalf("expected numeric worker field, got %#v", record["worker"])
 		}
-		sequence, ok := record["sequence"].(float64)
+		sequence, ok := numberAsInt(record["sequence"])
 		if !ok {
 			t.Fatalf("expected numeric sequence field, got %#v", record["sequence"])
 		}
-		key := fmt.Sprintf("%d:%d", int(worker), int(sequence))
+		key := fmt.Sprintf("%d:%d", worker, sequence)
 		if _, exists := seenPairs[key]; exists {
 			t.Fatalf("duplicate worker/sequence pair detected: %s", key)
 		}
@@ -156,15 +156,15 @@ func TestResourcesConcurrentWrites(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected entry to be a map, got %T", item)
 		}
-		worker, ok := record["worker"].(float64)
+		worker, ok := numberAsInt(record["worker"])
 		if !ok {
 			t.Fatalf("expected numeric worker field, got %#v", record["worker"])
 		}
-		sequence, ok := record["sequence"].(float64)
+		sequence, ok := numberAsInt(record["sequence"])
 		if !ok {
 			t.Fatalf("expected numeric sequence field, got %#v", record["sequence"])
 		}
-		key := fmt.Sprintf("%d:%d", int(worker), int(sequence))
+		key := fmt.Sprintf("%d:%d", worker, sequence)
 		if _, exists := seenPairs[key]; exists {
 			t.Fatalf("duplicate worker/sequence pair detected: %s", key)
 		}
@@ -181,5 +181,36 @@ func drainErr(errCh <-chan error) error {
 		return err
 	default:
 		return nil
+	}
+}
+
+func numberAsInt(value interface{}) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int8:
+		return int(v), true
+	case int16:
+		return int(v), true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case uint:
+		return int(v), true
+	case uint8:
+		return int(v), true
+	case uint16:
+		return int(v), true
+	case uint32:
+		return int(v), true
+	case uint64:
+		return int(v), true
+	case float32:
+		return int(v), true
+	case float64:
+		return int(v), true
+	default:
+		return 0, false
 	}
 }

--- a/app/database/concurrency_test.go
+++ b/app/database/concurrency_test.go
@@ -13,15 +13,25 @@ func TestEntriesConcurrentCreate(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(workers)
+	errCh := make(chan error, 1)
 	for i := 0; i < workers; i++ {
 		go func(worker int) {
 			defer wg.Done()
 			for j := 0; j < perWorker; j++ {
-				entry.Create(map[string]interface{}{"worker": worker, "sequence": j})
+				if _, err := entry.Create(map[string]interface{}{"worker": worker, "sequence": j}); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
 			}
 		}(i)
 	}
 	wg.Wait()
+	if err := drainErr(errCh); err != nil {
+		t.Fatalf("unexpected create error: %v", err)
+	}
 
 	got := len(entry.ReadAll())
 	want := workers * perWorker
@@ -73,20 +83,39 @@ func TestResourcesConcurrentWrites(t *testing.T) {
 	const perWorker = 40
 	var wg sync.WaitGroup
 	wg.Add(workers)
+	errCh := make(chan error, 1)
 	for i := 0; i < workers; i++ {
 		go func(worker int) {
 			defer wg.Done()
 			for j := 0; j < perWorker; j++ {
-				resource.Create(map[string]interface{}{"worker": worker, "sequence": j})
+				if _, err := resource.Create(map[string]interface{}{"worker": worker, "sequence": j}); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
 				resource.ReadAll()
 			}
 		}(i)
 	}
 	wg.Wait()
+	if err := drainErr(errCh); err != nil {
+		t.Fatalf("unexpected create error: %v", err)
+	}
 
 	total := len(resource.ReadAll())
 	want := workers * perWorker
 	if total != want {
 		t.Fatalf("expected %d records, got %d", want, total)
+	}
+}
+
+func drainErr(errCh <-chan error) error {
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return nil
 	}
 }

--- a/app/database/concurrency_test.go
+++ b/app/database/concurrency_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -37,6 +38,44 @@ func TestEntriesConcurrentCreate(t *testing.T) {
 	want := workers * perWorker
 	if got != want {
 		t.Fatalf("expected %d entries, got %d", want, got)
+	}
+
+	results := entry.ReadAll()
+	ids := make(map[string]struct{}, len(results))
+	seenPairs := make(map[string]struct{}, len(results))
+	for _, item := range results {
+		record, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected entry to be a map, got %T", item)
+		}
+		id, ok := record["_id"].(string)
+		if !ok || id == "" {
+			t.Fatalf("expected non-empty _id string, got %#v", record["_id"])
+		}
+		if _, exists := ids[id]; exists {
+			t.Fatalf("duplicate _id detected: %q", id)
+		}
+		ids[id] = struct{}{}
+
+		worker, ok := record["worker"].(float64)
+		if !ok {
+			t.Fatalf("expected numeric worker field, got %#v", record["worker"])
+		}
+		sequence, ok := record["sequence"].(float64)
+		if !ok {
+			t.Fatalf("expected numeric sequence field, got %#v", record["sequence"])
+		}
+		key := fmt.Sprintf("%d:%d", int(worker), int(sequence))
+		if _, exists := seenPairs[key]; exists {
+			t.Fatalf("duplicate worker/sequence pair detected: %s", key)
+		}
+		seenPairs[key] = struct{}{}
+	}
+	if len(ids) != want {
+		t.Fatalf("expected %d unique ids, got %d", want, len(ids))
+	}
+	if len(seenPairs) != want {
+		t.Fatalf("expected %d unique worker/sequence pairs, got %d", want, len(seenPairs))
 	}
 }
 
@@ -108,6 +147,31 @@ func TestResourcesConcurrentWrites(t *testing.T) {
 	want := workers * perWorker
 	if total != want {
 		t.Fatalf("expected %d records, got %d", want, total)
+	}
+
+	results := resource.ReadAll()
+	seenPairs := make(map[string]struct{}, len(results))
+	for _, item := range results {
+		record, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected entry to be a map, got %T", item)
+		}
+		worker, ok := record["worker"].(float64)
+		if !ok {
+			t.Fatalf("expected numeric worker field, got %#v", record["worker"])
+		}
+		sequence, ok := record["sequence"].(float64)
+		if !ok {
+			t.Fatalf("expected numeric sequence field, got %#v", record["sequence"])
+		}
+		key := fmt.Sprintf("%d:%d", int(worker), int(sequence))
+		if _, exists := seenPairs[key]; exists {
+			t.Fatalf("duplicate worker/sequence pair detected: %s", key)
+		}
+		seenPairs[key] = struct{}{}
+	}
+	if len(seenPairs) != want {
+		t.Fatalf("expected %d unique worker/sequence pairs, got %d", want, len(seenPairs))
 	}
 }
 

--- a/app/database/entries.go
+++ b/app/database/entries.go
@@ -1,12 +1,10 @@
 package database
 
 import (
-	b64 "encoding/base64"
 	"fmt"
-	"strconv"
 	"sync"
-	"time"
 
+	"github.com/gofrs/uuid/v5"
 	"github.com/icza/dyno"
 )
 
@@ -22,9 +20,7 @@ func NewEntry() Entries {
 func (e *Entries) Create(value interface{}) interface{} {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	// Generate key
-	now := time.Now().UnixNano()
-	key := b64.StdEncoding.EncodeToString([]byte(strconv.FormatInt(now, 10)))[0:15]
+	key := generateEntryKey()
 	if err := dyno.Set(value, key, "_id"); err != nil {
 		fmt.Printf("Failed to set _id: %v\n", err)
 	}
@@ -64,4 +60,13 @@ func (e *Entries) Del(key string) bool {
 	delete(e.database, key)
 	_, prs := e.database[key]
 	return !prs
+}
+
+func generateEntryKey() string {
+	u, err := uuid.NewV7()
+	if err != nil {
+		fmt.Printf("failed to generate uuid v7: %v\n", err)
+		return uuid.Must(uuid.NewV7()).String()
+	}
+	return u.String()
 }

--- a/app/database/entries.go
+++ b/app/database/entries.go
@@ -3,24 +3,28 @@ package database
 import (
 	b64 "encoding/base64"
 	"fmt"
-	"github.com/icza/dyno"
 	"strconv"
+	"sync"
 	"time"
+
+	"github.com/icza/dyno"
 )
 
 type Entries struct {
+	mu       sync.RWMutex
 	database map[string]interface{}
 }
 
 func NewEntry() Entries {
-	return Entries{make(map[string]interface{})}
+	return Entries{database: make(map[string]interface{})}
 }
 
 func (e *Entries) Create(value interface{}) interface{} {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	// Generate key
 	now := time.Now().UnixNano()
 	key := b64.StdEncoding.EncodeToString([]byte(strconv.FormatInt(now, 10)))[0:15]
-	// Set ID
 	if err := dyno.Set(value, key, "_id"); err != nil {
 		fmt.Printf("Failed to set _id: %v\n", err)
 	}
@@ -29,10 +33,14 @@ func (e *Entries) Create(value interface{}) interface{} {
 }
 
 func (e *Entries) Read(key string) interface{} {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return e.database[key]
 }
 
 func (e *Entries) ReadAll() []interface{} {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	values := make([]interface{}, 0, len(e.database))
 	for _, val := range e.database {
 		values = append(values, val)
@@ -41,7 +49,8 @@ func (e *Entries) ReadAll() []interface{} {
 }
 
 func (e *Entries) Update(key string, value interface{}) interface{} {
-	// Set ID
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	if err := dyno.Set(value, key, "_id"); err != nil {
 		fmt.Printf("Failed to set _id: %v\n", err)
 	}
@@ -50,6 +59,8 @@ func (e *Entries) Update(key string, value interface{}) interface{} {
 }
 
 func (e *Entries) Del(key string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	delete(e.database, key)
 	_, prs := e.database[key]
 	return !prs

--- a/app/database/entries.go
+++ b/app/database/entries.go
@@ -17,15 +17,15 @@ func NewEntry() Entries {
 	return Entries{database: make(map[string]interface{})}
 }
 
-func (e *Entries) Create(value interface{}) interface{} {
+func (e *Entries) Create(value interface{}) (interface{}, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	key := generateEntryKey()
 	if err := dyno.Set(value, key, "_id"); err != nil {
-		fmt.Printf("Failed to set _id: %v\n", err)
+		return nil, fmt.Errorf("failed to set _id: %w", err)
 	}
 	e.database[key] = value
-	return e.database[key]
+	return e.database[key], nil
 }
 
 func (e *Entries) Read(key string) interface{} {
@@ -44,14 +44,14 @@ func (e *Entries) ReadAll() []interface{} {
 	return values
 }
 
-func (e *Entries) Update(key string, value interface{}) interface{} {
+func (e *Entries) Update(key string, value interface{}) (interface{}, error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if err := dyno.Set(value, key, "_id"); err != nil {
-		fmt.Printf("Failed to set _id: %v\n", err)
+		return nil, fmt.Errorf("failed to set _id: %w", err)
 	}
 	e.database[key] = value
-	return e.database[key]
+	return e.database[key], nil
 }
 
 func (e *Entries) Del(key string) bool {

--- a/app/database/resources.go
+++ b/app/database/resources.go
@@ -2,37 +2,49 @@ package database
 
 import (
 	"fmt"
+	"sync"
 )
 
 type Resources struct {
+	mu       sync.RWMutex
 	database map[string]*Entries
 }
 
 func NewDatabase() Resources {
-	return Resources{make(map[string]*Entries)}
+	return Resources{database: make(map[string]*Entries)}
 }
 
-func (r *Resources) NewResource(name string) (*Resources, error) {
-	if !r.Exists(name) {
-		entry := NewEntry()
-		r.database[name] = &entry
-		return r, nil
-	} else {
-		err := fmt.Errorf("resource %q already exists", name)
-		return nil, err
+func (r *Resources) NewResource(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.database[name]; exists {
+		return fmt.Errorf("resource %q already exists", name)
 	}
+	entry := NewEntry()
+	r.database[name] = &entry
+	return nil
 }
 
 func (r *Resources) Get(name string) *Entries {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.database[name]
 }
 
 func (r *Resources) Exists(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	_, prs := r.database[name]
 	return prs
 }
 
 func (r *Resources) Remove(name string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.database[name]; !exists {
+		return false
+	}
 	delete(r.database, name)
-	return r.Exists(name)
+	_, stillExists := r.database[name]
+	return !stillExists
 }

--- a/app/database/resources.go
+++ b/app/database/resources.go
@@ -10,8 +10,8 @@ type Resources struct {
 	database map[string]*Entries
 }
 
-func NewDatabase() Resources {
-	return Resources{database: make(map[string]*Entries)}
+func NewDatabase() *Resources {
+	return &Resources{database: make(map[string]*Entries)}
 }
 
 func (r *Resources) NewResource(name string) error {

--- a/app/handler/resource.go
+++ b/app/handler/resource.go
@@ -3,10 +3,11 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/andy-ta/andydb/app/database"
-	"github.com/gorilla/mux"
 	"io"
 	"net/http"
+
+	"github.com/andy-ta/andydb/app/database"
+	"github.com/gorilla/mux"
 )
 
 const maxRequestBodySize = 1 << 20

--- a/app/handler/resource.go
+++ b/app/handler/resource.go
@@ -16,9 +16,8 @@ func Get(w http.ResponseWriter, r *http.Request, database *database.Resources) {
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	key := vars["id"]
-	resource := database.Get(resourceName)
-	if resource == nil {
-		respondError(w, http.StatusNotFound, fmt.Sprintf("resource %q does not exist", resourceName))
+	resource, ok := resolveResource(w, database, resourceName, true)
+	if !ok {
 		return
 	}
 	entry := resource.Read(key)
@@ -32,9 +31,8 @@ func Get(w http.ResponseWriter, r *http.Request, database *database.Resources) {
 func GetAll(w http.ResponseWriter, r *http.Request, database *database.Resources) {
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
-	resource := database.Get(resourceName)
-	if resource == nil {
-		respondError(w, http.StatusNotFound, fmt.Sprintf("resource %q does not exist", resourceName))
+	resource, ok := resolveResource(w, database, resourceName, true)
+	if !ok {
 		return
 	}
 	respondJSON(w, http.StatusOK, resource.ReadAll())
@@ -44,9 +42,8 @@ func Update(w http.ResponseWriter, r *http.Request, database *database.Resources
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	key := vars["id"]
-	resource := database.Get(resourceName)
-	if resource == nil {
-		respondError(w, http.StatusNotFound, fmt.Sprintf("resource %q does not exist", resourceName))
+	resource, ok := resolveResource(w, database, resourceName, true)
+	if !ok {
 		return
 	}
 	body, err := parseBody(r)
@@ -66,9 +63,8 @@ func Delete(w http.ResponseWriter, r *http.Request, database *database.Resources
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	key := vars["id"]
-	resource := database.Get(resourceName)
-	if resource == nil {
-		respondError(w, http.StatusNotFound, fmt.Sprintf("resource %q does not exist", resourceName))
+	resource, ok := resolveResource(w, database, resourceName, true)
+	if !ok {
 		return
 	}
 	if deleted := resource.Del(key); !deleted {
@@ -81,8 +77,8 @@ func Delete(w http.ResponseWriter, r *http.Request, database *database.Resources
 func Create(w http.ResponseWriter, r *http.Request, database *database.Resources) {
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
-	resource := database.Get(resourceName)
-	if resource == nil {
+	resource, exists := resolveResource(w, database, resourceName, false)
+	if !exists {
 		if err := database.NewResource(resourceName); err != nil {
 			resource = database.Get(resourceName)
 			if resource == nil {
@@ -127,4 +123,13 @@ func parseBody(r *http.Request) (interface{}, error) {
 		return nil, fmt.Errorf("invalid JSON: %w", err)
 	}
 	return entry, nil
+}
+
+func resolveResource(w http.ResponseWriter, database *database.Resources, resourceName string, respondIfMissing bool) (*database.Entries, bool) {
+	resource := database.Get(resourceName)
+	if resource == nil && respondIfMissing {
+		respondError(w, http.StatusNotFound, fmt.Sprintf("resource %q does not exist", resourceName))
+		return nil, false
+	}
+	return resource, resource != nil
 }

--- a/app/handler/resource.go
+++ b/app/handler/resource.go
@@ -54,9 +54,9 @@ func Update(w http.ResponseWriter, r *http.Request, database *database.Resources
 		respondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	entry := resource.Update(key, body)
-	if entry == nil {
-		respondError(w, http.StatusNotFound, fmt.Sprintf("id %q does not exist", key))
+	entry, err := resource.Update(key, body)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	respondJSON(w, http.StatusOK, entry)
@@ -102,7 +102,11 @@ func Create(w http.ResponseWriter, r *http.Request, database *database.Resources
 		respondError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	result := resource.Create(body)
+	result, err := resource.Create(body)
+	if err != nil {
+		respondError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
 	respondJSON(w, http.StatusCreated, result)
 }
 

--- a/app/handler/resource.go
+++ b/app/handler/resource.go
@@ -5,140 +5,121 @@ import (
 	"fmt"
 	"github.com/andy-ta/andydb/app/database"
 	"github.com/gorilla/mux"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
+const maxRequestBodySize = 1 << 20
+
 func Get(w http.ResponseWriter, r *http.Request, database database.Resources) {
-	var err error
-	code := http.StatusInternalServerError
-	var response interface{}
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	key := vars["id"]
-
-	if result := database.Get(resourceName); result != nil {
-		if response = result.Read(key); response != nil {
-			respondJSON(w, http.StatusOK, response)
-		} else {
-			code = http.StatusNotFound
-			err = fmt.Errorf("id %q does not exist", key)
-		}
-	} else {
-		code = http.StatusNotFound
-		err = fmt.Errorf("resource %q does not exist", resourceName)
+	resource := database.Get(resourceName)
+	if resource == nil {
+		respondError(w, http.StatusNotFound, fmt.Sprintf("resource %q does not exist", resourceName))
+		return
 	}
-
-	if err != nil {
-		respondError(w, code, err.Error())
+	entry := resource.Read(key)
+	if entry == nil {
+		respondError(w, http.StatusNotFound, fmt.Sprintf("id %q does not exist", key))
+		return
 	}
+	respondJSON(w, http.StatusOK, entry)
 }
 
 func GetAll(w http.ResponseWriter, r *http.Request, database database.Resources) {
-	var err error
-	code := http.StatusInternalServerError
-	var response []interface{}
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
-
-	if result := database.Get(resourceName); result != nil {
-		if response = result.ReadAll(); response != nil {
-			respondJSON(w, http.StatusOK, response)
-		} else {
-			err = fmt.Errorf("entries for %q not found", resourceName)
-		}
-	} else {
-		code = http.StatusNotFound
-		err = fmt.Errorf("resource %q does not exist", resourceName)
+	resource := database.Get(resourceName)
+	if resource == nil {
+		respondError(w, http.StatusNotFound, fmt.Sprintf("resource %q does not exist", resourceName))
+		return
 	}
-
-	if err != nil {
-		respondError(w, code, err.Error())
-	}
+	respondJSON(w, http.StatusOK, resource.ReadAll())
 }
 
 func Update(w http.ResponseWriter, r *http.Request, database database.Resources) {
-	var err error
-	code := http.StatusInternalServerError
-	var response interface{}
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	key := vars["id"]
-
-	if result := database.Get(resourceName); result != nil {
-		body, err := getBody(r)
-		if err == nil {
-			if response = result.Update(key, body); response != nil {
-				respondJSON(w, http.StatusOK, response)
-			} else {
-				code = http.StatusNotFound
-				err = fmt.Errorf("id %q does not exist", key)
-			}
-		} else {
-			code = http.StatusBadRequest
-			err = fmt.Errorf("invalid body %q", body)
-		}
-	} else {
-		code = http.StatusNotFound
-		err = fmt.Errorf("resource %q does not exist", resourceName)
+	resource := database.Get(resourceName)
+	if resource == nil {
+		respondError(w, http.StatusNotFound, fmt.Sprintf("resource %q does not exist", resourceName))
+		return
 	}
-
+	body, err := parseBody(r)
 	if err != nil {
-		respondError(w, code, err.Error())
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
 	}
+	entry := resource.Update(key, body)
+	if entry == nil {
+		respondError(w, http.StatusNotFound, fmt.Sprintf("id %q does not exist", key))
+		return
+	}
+	respondJSON(w, http.StatusOK, entry)
 }
 
 func Delete(w http.ResponseWriter, r *http.Request, database database.Resources) {
-	var err error
-	code := http.StatusInternalServerError
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	key := vars["id"]
-
-	if result := database.Get(resourceName); result != nil {
-		if deleted := result.Del(key); deleted {
-			respondJSON(w, http.StatusNoContent, nil)
-		} else {
-			err = fmt.Errorf("failed to delete id %q", key)
-		}
-	} else {
-		code = http.StatusBadRequest
-		err = fmt.Errorf("resource %q does not exist", resourceName)
+	resource := database.Get(resourceName)
+	if resource == nil {
+		respondError(w, http.StatusNotFound, fmt.Sprintf("resource %q does not exist", resourceName))
+		return
 	}
-
-	if err != nil {
-		respondError(w, code, err.Error())
+	if deleted := resource.Del(key); !deleted {
+		respondError(w, http.StatusNotFound, fmt.Sprintf("id %q does not exist", key))
+		return
 	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func Create(w http.ResponseWriter, r *http.Request, database database.Resources) {
-	var err error
-	var result interface{}
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
-
-	// If the resource does not exist yet.
-	if !database.Exists(resourceName) {
-		r, e := database.NewResource(vars["resource"])
-		result = r
-		err = e
+	resource := database.Get(resourceName)
+	if resource == nil {
+		if err := database.NewResource(resourceName); err != nil {
+			resource = database.Get(resourceName)
+			if resource == nil {
+				respondError(w, http.StatusConflict, err.Error())
+				return
+			}
+		} else {
+			resource = database.Get(resourceName)
+		}
 	}
-
-	// Create the entry
-	entry, err := getBody(r)
-	result = database.Get(resourceName).Create(entry)
-
-	if err == nil {
-		respondJSON(w, http.StatusOK, result)
-	} else {
-		respondError(w, http.StatusConflict, err.Error())
+	if resource == nil {
+		respondError(w, http.StatusInternalServerError, fmt.Sprintf("failed to prepare resource %q", resourceName))
+		return
 	}
+	body, err := parseBody(r)
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	result := resource.Create(body)
+	respondJSON(w, http.StatusCreated, result)
 }
 
-func getBody(r *http.Request) (interface{}, error) {
+func parseBody(r *http.Request) (interface{}, error) {
+	limitedReader := io.LimitReader(r.Body, maxRequestBodySize+1)
+	body, err := io.ReadAll(limitedReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read request body: %w", err)
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("request body is empty")
+	}
+	if len(body) > maxRequestBodySize {
+		return nil, fmt.Errorf("request body exceeds %d bytes", maxRequestBodySize)
+	}
 	var entry interface{}
-	body, e := ioutil.ReadAll(r.Body)
-	bodyString := string(body)
-	e = json.Unmarshal([]byte(bodyString), &entry)
-	return entry, e
+	if err := json.Unmarshal(body, &entry); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	return entry, nil
 }

--- a/app/handler/resource.go
+++ b/app/handler/resource.go
@@ -11,7 +11,7 @@ import (
 
 const maxRequestBodySize = 1 << 20
 
-func Get(w http.ResponseWriter, r *http.Request, database database.Resources) {
+func Get(w http.ResponseWriter, r *http.Request, database *database.Resources) {
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	key := vars["id"]
@@ -28,7 +28,7 @@ func Get(w http.ResponseWriter, r *http.Request, database database.Resources) {
 	respondJSON(w, http.StatusOK, entry)
 }
 
-func GetAll(w http.ResponseWriter, r *http.Request, database database.Resources) {
+func GetAll(w http.ResponseWriter, r *http.Request, database *database.Resources) {
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	resource := database.Get(resourceName)
@@ -39,7 +39,7 @@ func GetAll(w http.ResponseWriter, r *http.Request, database database.Resources)
 	respondJSON(w, http.StatusOK, resource.ReadAll())
 }
 
-func Update(w http.ResponseWriter, r *http.Request, database database.Resources) {
+func Update(w http.ResponseWriter, r *http.Request, database *database.Resources) {
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	key := vars["id"]
@@ -61,7 +61,7 @@ func Update(w http.ResponseWriter, r *http.Request, database database.Resources)
 	respondJSON(w, http.StatusOK, entry)
 }
 
-func Delete(w http.ResponseWriter, r *http.Request, database database.Resources) {
+func Delete(w http.ResponseWriter, r *http.Request, database *database.Resources) {
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	key := vars["id"]
@@ -77,7 +77,7 @@ func Delete(w http.ResponseWriter, r *http.Request, database database.Resources)
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func Create(w http.ResponseWriter, r *http.Request, database database.Resources) {
+func Create(w http.ResponseWriter, r *http.Request, database *database.Resources) {
 	vars := mux.Vars(r)
 	resourceName := vars["resource"]
 	resource := database.Get(resourceName)

--- a/app/handler/resource_test.go
+++ b/app/handler/resource_test.go
@@ -1,0 +1,237 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/andy-ta/andydb/app/database"
+	"github.com/gorilla/mux"
+)
+
+func TestParseBodyValidJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"name":"andy"}`))
+	body, err := parseBody(req)
+	if err != nil {
+		t.Fatalf("parseBody returned error: %v", err)
+	}
+	m, ok := body.(map[string]interface{})
+	if !ok || m["name"] != "andy" {
+		t.Fatalf("unexpected body: %#v", body)
+	}
+}
+
+func TestParseBodyTooLarge(t *testing.T) {
+	large := strings.Repeat("a", maxRequestBodySize+1)
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(large))
+	if _, err := parseBody(req); err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("expected size error, got %v", err)
+	}
+}
+
+func TestParseBodyInvalidJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("{notjson}"))
+	if _, err := parseBody(req); err == nil || !strings.Contains(err.Error(), "invalid JSON") {
+		t.Fatalf("expected invalid JSON error, got %v", err)
+	}
+}
+
+func TestParseBodyEmptyBody(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+	if _, err := parseBody(req); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("expected empty body error, got %v", err)
+	}
+}
+
+func TestResolveResourceNotFound(t *testing.T) {
+	db := database.NewDatabase()
+	recorder := httptest.NewRecorder()
+	res, ok := resolveResource(recorder, db, "missing", true)
+	if ok || res != nil {
+		t.Fatalf("expected missing result, got %v", res)
+	}
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", recorder.Code)
+	}
+}
+
+func TestResolveResourceFound(t *testing.T) {
+	db := database.NewDatabase()
+	if err := db.NewResource("found"); err != nil {
+		t.Fatalf("failed to create resource: %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	res, ok := resolveResource(recorder, db, "found", true)
+	if !ok || res == nil {
+		t.Fatalf("expected resource, got %v", res)
+	}
+	if recorder.Body.Len() != 0 {
+		t.Fatalf("expected no response body, got %q", recorder.Body.String())
+	}
+}
+
+func TestCRUDHandlers(t *testing.T) {
+	db := database.NewDatabase()
+	resourceName := "contacts"
+
+	first := createEntry(t, db, resourceName, `{"name":"andy"}`)
+	second := createEntry(t, db, resourceName, `{"name":"betty"}`)
+
+	if first["_id"] == second["_id"] {
+		t.Fatalf("expected distinct ids, got %q", first["_id"])
+	}
+
+	getReq := httptest.NewRequest(http.MethodGet, "/api/contacts/"+first["_id"].(string), nil)
+	getReq = mux.SetURLVars(getReq, map[string]string{"resource": resourceName, "id": first["_id"].(string)})
+	getRec := httptest.NewRecorder()
+	Get(getRec, getReq, db)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on get, got %d (%s)", getRec.Code, getRec.Body.String())
+	}
+	if ct := getRec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json content type, got %q", ct)
+	}
+	got := decodeMap(t, getRec)
+	if got["name"] != "andy" {
+		t.Fatalf("expected name=andy, got %v", got["name"])
+	}
+	if got["_id"] != first["_id"] {
+		t.Fatalf("expected same id on get, got %v", got["_id"])
+	}
+
+	getAllReq := httptest.NewRequest(http.MethodGet, "/api/contacts", nil)
+	getAllReq = mux.SetURLVars(getAllReq, map[string]string{"resource": resourceName})
+	getAllRec := httptest.NewRecorder()
+	GetAll(getAllRec, getAllReq, db)
+	if getAllRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on get all, got %d (%s)", getAllRec.Code, getAllRec.Body.String())
+	}
+	list := decodeSlice(t, getAllRec)
+	if len(list) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(list))
+	}
+	if !hasID(list, first["_id"]) || !hasID(list, second["_id"]) {
+		t.Fatalf("expected get all to include both created ids, got %#v", list)
+	}
+
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/contacts/"+first["_id"].(string), strings.NewReader(`{"name":"andy-updated"}`))
+	updateReq = mux.SetURLVars(updateReq, map[string]string{"resource": resourceName, "id": first["_id"].(string)})
+	updateRec := httptest.NewRecorder()
+	Update(updateRec, updateReq, db)
+	if updateRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on update, got %d", updateRec.Code)
+	}
+	updated := decodeMap(t, updateRec)
+	if updated["_id"] != first["_id"] {
+		t.Fatalf("expected id unchanged, got %v", updated["_id"])
+	}
+	if updated["name"] != "andy-updated" {
+		t.Fatalf("expected updated name, got %v", updated["name"])
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/contacts/"+first["_id"].(string), nil)
+	deleteReq = mux.SetURLVars(deleteReq, map[string]string{"resource": resourceName, "id": first["_id"].(string)})
+	deleteRec := httptest.NewRecorder()
+	Delete(deleteRec, deleteReq, db)
+	if deleteRec.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 on delete, got %d", deleteRec.Code)
+	}
+
+	confirmReq := httptest.NewRequest(http.MethodGet, "/api/contacts/"+first["_id"].(string), nil)
+	confirmReq = mux.SetURLVars(confirmReq, map[string]string{"resource": resourceName, "id": first["_id"].(string)})
+	confirmRec := httptest.NewRecorder()
+	Get(confirmRec, confirmReq, db)
+	if confirmRec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 after delete, got %d", confirmRec.Code)
+	}
+	confirmErr := decodeError(t, confirmRec)
+	if !strings.Contains(confirmErr, first["_id"].(string)) {
+		t.Fatalf("expected not-found message to include missing id, got %q", confirmErr)
+	}
+}
+
+func TestCreateInvalidBodyReturnsBadRequest(t *testing.T) {
+	db := database.NewDatabase()
+	req := httptest.NewRequest(http.MethodPost, "/api/contacts", strings.NewReader("{invalid-json"))
+	req = mux.SetURLVars(req, map[string]string{"resource": "contacts"})
+	rec := httptest.NewRecorder()
+
+	Create(rec, req, db)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid create body, got %d", rec.Code)
+	}
+	if got := decodeError(t, rec); !strings.Contains(got, "invalid JSON") {
+		t.Fatalf("expected invalid JSON error, got %q", got)
+	}
+}
+
+func TestGetMissingResourceReturnsNotFoundErrorPayload(t *testing.T) {
+	db := database.NewDatabase()
+	req := httptest.NewRequest(http.MethodGet, "/api/missing/abc", nil)
+	req = mux.SetURLVars(req, map[string]string{"resource": "missing", "id": "abc"})
+	rec := httptest.NewRecorder()
+
+	Get(rec, req, db)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing resource, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json content type, got %q", ct)
+	}
+	if got := decodeError(t, rec); !strings.Contains(got, "resource \"missing\" does not exist") {
+		t.Fatalf("unexpected error payload: %q", got)
+	}
+}
+
+func createEntry(t *testing.T, db *database.Resources, resourceName, payload string) map[string]interface{} {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/"+resourceName, strings.NewReader(payload))
+	req = mux.SetURLVars(req, map[string]string{"resource": resourceName})
+	rec := httptest.NewRecorder()
+	Create(rec, req, db)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 from create, got %d", rec.Code)
+	}
+	return decodeMap(t, rec)
+}
+
+func decodeMap(t *testing.T, rec *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var value map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &value); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return value
+}
+
+func decodeSlice(t *testing.T, rec *httptest.ResponseRecorder) []map[string]interface{} {
+	t.Helper()
+	var values []map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &values); err != nil {
+		t.Fatalf("failed to decode response slice: %v", err)
+	}
+	return values
+}
+
+func decodeError(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	decoded := decodeMap(t, rec)
+	err, ok := decoded["error"].(string)
+	if !ok {
+		t.Fatalf("expected error string field, got %#v", decoded)
+	}
+	return err
+}
+
+func hasID(values []map[string]interface{}, id interface{}) bool {
+	for _, value := range values {
+		if value["_id"] == id {
+			return true
+		}
+	}
+	return false
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/andy-ta/andydb
+
+go 1.25.0
+
+require (
+	github.com/gorilla/mux v1.8.1
+	github.com/icza/dyno v0.0.0-20230330125955-09f820a8d9c0
+)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/andy-ta/andydb
 go 1.25.0
 
 require (
+	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/gorilla/mux v1.8.1
 	github.com/icza/dyno v0.0.0-20230330125955-09f820a8d9c0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/icza/dyno v0.0.0-20230330125955-09f820a8d9c0 h1:nHoRIX8iXob3Y2kdt9KsjyIb7iApSvb3vgsd93xb5Ow=
+github.com/icza/dyno v0.0.0-20230330125955-09f820a8d9c0/go.mod h1:c1tRKs5Tx7E2+uHGSyyncziFjvGpgv4H2HrqXeUQ/Uk=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
+github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/icza/dyno v0.0.0-20230330125955-09f820a8d9c0 h1:nHoRIX8iXob3Y2kdt9KsjyIb7iApSvb3vgsd93xb5Ow=

--- a/main.go
+++ b/main.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"log"
+	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -15,12 +17,18 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	envMode := os.Getenv("ANDYDB_ENV")
+	devMode := strings.EqualFold(envMode, "dev")
+	if envMode == "" && runningUnderGoRun() {
+		devMode = true
+	}
 	cfg := app.ServerConfig{
 		Addr:            ":42069",
 		ReadTimeout:     5 * time.Second,
 		WriteTimeout:    5 * time.Second,
 		IdleTimeout:     120 * time.Second,
 		ShutdownTimeout: 5 * time.Second,
+		DevMode:         devMode,
 	}
 
 	server := &app.App{}
@@ -28,4 +36,8 @@ func main() {
 	if err := server.Run(ctx, cfg); err != nil && !errors.Is(err, context.Canceled) {
 		log.Fatalf("server terminated: %v", err)
 	}
+}
+
+func runningUnderGoRun() bool {
+	return strings.Contains(os.Args[0], "go-build")
 }

--- a/main.go
+++ b/main.go
@@ -1,12 +1,31 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"log"
+	"os/signal"
+	"syscall"
+	"time"
+
 	"github.com/andy-ta/andydb/app"
 )
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	cfg := app.ServerConfig{
+		Addr:            ":42069",
+		ReadTimeout:     5 * time.Second,
+		WriteTimeout:    5 * time.Second,
+		IdleTimeout:     120 * time.Second,
+		ShutdownTimeout: 5 * time.Second,
+	}
 
 	server := &app.App{}
 	server.Initialize()
-	server.Run(":42069")
+	if err := server.Run(ctx, cfg); err != nil && !errors.Is(err, context.Canceled) {
+		log.Fatalf("server terminated: %v", err)
+	}
 }


### PR DESCRIPTION
# PR Description

## Summary
This PR modernizes the AndyDB runtime and improves safety around concurrent data access and request handling.

## Changes
- **Server lifecycle and middleware**
  - Added `ServerConfig` and changed startup to `App.Run(ctx, cfg)` with explicit read/write/idle/shutdown timeouts.
  - Added graceful shutdown via `signal.NotifyContext` in `main.go`.
  - Added panic recovery middleware and optional dev request logging middleware.
  - Added dev/prod mode behavior using `ANDYDB_ENV` (with `go run .` defaulting to dev mode).

- **Database concurrency and IDs**
  - Added `sync.RWMutex` protection to in-memory `Entries` and `Resources`.
  - Switched resource store constructor to return `*Resources`.
  - Updated entry ID generation from time-based/base64 keys to UUID v7.
  - Updated `Entries.Create` and `Entries.Update` to return `(interface{}, error)` for explicit error propagation.

- **HTTP handler reliability**
  - Updated handlers to use `*database.Resources`.
  - Refactored resource lookup into `resolveResource`.
  - Replaced body parsing with `parseBody` using a 1MB limit and explicit errors for empty/invalid/oversized payloads.
  - Standardized JSON error handling and response codes across CRUD endpoints.

- **Tests and docs**
  - Added `app/database/concurrency_test.go` with concurrent resource/entry test coverage.
  - Added `app/handler/resource_test.go` with CRUD and validation/error-path coverage.
  - Updated `README.md` with dev mode, safety, and shutdown notes.
  - Added module dependency files (`go.mod`, `go.sum`) including `github.com/gofrs/uuid/v5`.